### PR TITLE
Printfix

### DIFF
--- a/src/Gakco.cpp
+++ b/src/Gakco.cpp
@@ -279,10 +279,8 @@ int main(int argc, char *argv[]) {
 	test_K = gsvm.construct_test_kernel();
 	//gsvm.write_test_kernel();
 
-	double acc = gsvm.predict(test_K, gsvm.test_labels);
+	double auc = gsvm.predict(test_K, gsvm.test_labels);
 
-	if(arg.probability)
-		printf("auc: %f\n", acc);
 
 
 	return 0;

--- a/src/Gakco.cpp
+++ b/src/Gakco.cpp
@@ -36,7 +36,6 @@ int help() {
 	printf("\t m : maximum number of mismatches when comparing two gmers. Constraints: 0 <= m < g\n");
 	printf("\t t : (optional) number of threads to use. Set to 1 to not parallelize kernel computation\n");
 	printf("\t C : (optional) SVM C parameter. Default is 1.0\n");
-	printf("\t p : (optional) Flag to generate probability of class or not. Without it, AUC can't be calculated Default is 0\n");
 	printf("\t k : (optional) Specify a kernel filename to print to. If -l is also set, this will instead be used as the filename to load the kernel from\n");
 	printf("\t o : (optional) Specify a model filename to print to. If -s is also set, this will instead be used as the filename to load the model from\n");
 	printf("\t r : (optional) 1 for GAKCO (default), 2 for LINEAR");
@@ -277,7 +276,7 @@ int main(int argc, char *argv[]) {
 		return 0;
 
 	test_K = gsvm.construct_test_kernel();
-	//gsvm.write_test_kernel();
+	gsvm.write_test_kernel();
 
 	double auc = gsvm.predict(test_K, gsvm.test_labels);
 

--- a/src/GakcoSVM.cpp
+++ b/src/GakcoSVM.cpp
@@ -576,28 +576,32 @@ void* GakcoSVM::train(double* K) {
 //file output name specified via command line or specially by modifying the parameter struct
 void GakcoSVM::write_files() {
 	FILE *kernelfile;
+	FILE *labelfile;
 	std::string kernelfileName = this->params->outputFilename;
 	if(kernelfileName.empty()){
 		kernelfileName = "kernel.txt";
 	}
 	printf("Writing kernel to %s\n", kernelfileName.c_str());
 	kernelfile = fopen(kernelfileName.c_str(), "w");
+	labelfile = fopen("train_labels.txt", "w");
 	int nStr = this->nStr;
 
 	for (int i = 0; i < nStr; ++i) {	
-		for (int j = 0; j < nStr; ++j) {
+		for (int j = 0; j <= i; ++j) {
 			fprintf(kernelfile, "%d:%e ", j + 1, this->kernel[i + j*nStr] );
 		}
 		fprintf(kernelfile, "\n");
+		fprintf(labelfile, "%d\n", this->labels[i]);
 	}
 	fclose(kernelfile);
+	fclose(labelfile);
 }
 
 void GakcoSVM::write_test_kernel() {
 	FILE *kernelfile;
 	FILE *labelfile;
 	kernelfile = fopen("test_Kernel.txt", "w");
-	//labelfile = fopen(this->params->labelFilename.c_str(), "w");
+	labelfile = fopen(this->params->labelFilename.c_str(), "w");
 	int nStr = this->nStr;
 	int nTestStr = this->nTestStr;
 	int num_sv = this->model->nSV[0] + this->model->nSV[1];
@@ -609,13 +613,12 @@ void GakcoSVM::write_test_kernel() {
 		{
 			fprintf(kernelfile, "%d:%e ", this->model->sv_indices[j], this->test_kernel[j + i*num_sv]);
 		}
-		//fprintf(labelfile, "%d ", this->labels[i]);
-		//fprintf(labelfile, "\n");
+		fprintf(labelfile, "%d\n", this->test_labels[i]);
 		fprintf(kernelfile, "\n");
 	}
 		
 	fclose(kernelfile);
-	//fclose(labelfile);
+	fclose(labelfile);
 }
 
 


### PR DESCRIPTION
Fixed some auc print oddness, also now label files for both train and test files are printed, and the kernels are also both printed. The train kernel is printed as lower triangular and the test kernel is not, as it is not symmetrical. 